### PR TITLE
Fix Podimo API drift, switch to .env, organize downloads per podcast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PODIMO_EMAIL=your podimo email
+PODIMO_PASSWORD=your podimo password
+PODIMO_IS_CREATOR=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 config.py
+.venv/
 __pycache__/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ config.py
 .venv/
 __pycache__/
 .env
+episodes/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ No lint config. Install deps with `pip install -r requirements.txt`.
 
 ```bash
 # Run the downloader (interactive prompts unless flags / env vars fill them in)
-python podimo-dl.py [-p PODCAST_NAME] [-d] [--premium-only] [--overwrite] [-o OUTPUT_DIR]
+python podimo-dl.py [-p PODCAST_NAME_OR_UUID] [-d] [--premium-only] [--overwrite] [-o OUTPUT_BASE_DIR]
 
 # Regenerate queries.py and mutations.py from Podimo's JS bundles
 python generate.py
@@ -21,7 +21,7 @@ python -m unittest test_podimo_dl.GetPodcastEpisodesTest.test_paginates_until_sh
 
 Note: `test_podimo_dl.py` imports `podimo-dl.py` via `importlib.util` because the hyphenated filename isn't a legal Python module name.
 
-CLI flags: `-d/--download` skips the "Download Episodes?" prompt; `--premium-only` filters to PREMIUM episodes; `--overwrite` re-downloads existing files.
+CLI flags: `-p` accepts either a podcast name (substring-matched against autocomplete results, first hit wins) or a UUID matching `8-4-4-4-12` hex — UUIDs short-circuit search and are passed straight to `get_podcast_episodes`. `-d/--download` skips the "Download Episodes?" prompt; `--premium-only` filters to PREMIUM episodes; `--overwrite` re-downloads existing files; `-o` overrides the output base directory (default `episodes/`). Files land at `<base>/<sanitized podcast title>/<sanitized episode title>.mp3`; the per-podcast folder is created if missing. For UUID input, `get_podcast_title` (one extra `podcastById` call) supplies the folder name, falling back to the UUID if the lookup returns nothing.
 
 Credentials come from `.env` (gitignored, copied from `.env.example`): `PODIMO_EMAIL`, `PODIMO_PASSWORD`, `PODIMO_IS_CREATOR`. Any unset value falls through to an interactive prompt; `PODIMO_IS_CREATOR` is parsed as truthy on `1`/`true`/`yes`.
 
@@ -33,8 +33,10 @@ This is a single-purpose CLI that downloads podcast episodes from Podimo via the
 - `studio_client` → `https://studio.podimo.com/graphql` (used only when `is_creator=True`, with `scope: 'CREATOR'`)
 - `public_client` → `https://podimo.com/graphql` (everything else: search, episode listing)
 
-After `login()`, both transports get a shared `Host: graphql.pdm-gateway.com` header alongside the bearer token — Podimo routes the request URLs through that gateway, so this header override is required for subsequent calls to authenticate.
+After `login()`, both transports share a token-bearing header set (no `Host` override — earlier versions set `Host: graphql.pdm-gateway.com` but the current API works without it; re-add if requests start 401-ing post-login).
 
-The flow is: `login` → `search_podcast` (substring-filters `publicSearch` results by title and returns the first match) → `get_podcast_episodes` → `download_episode` (urllib download, then `eyed3` writes ID3v2.4 tags). Track numbers are parsed from title prefixes like `#42 Episode Title` via regex; otherwise track 0.
+The flow is: `login` → resolve podcast id (UUID input is used directly + `get_podcast_title` fetches the title for folder naming; otherwise `search_podcast` substring-filters `podcastsAutocomplete` results by title and returns the first hit) → `get_podcast_episodes` (paginates `podcastEpisodes` until a short page) → `download_episode` (urllib download into `<base>/<podcast>/`, then `eyed3` writes ID3v2.4 tags). Track numbers are parsed from title prefixes like `#42 Episode Title` via regex; otherwise track 0.
 
-**`queries.py` and `mutations.py` are AUTO-GENERATED — do not hand-edit.** They are produced by `generate.py`, which fetches Podimo's webpack bundles and extracts every embedded `query …` / `mutation …` string. The bundle URLs hard-coded in `generate.py` (`js_url`, `js_studio_urls`) are versioned and will 404 when Podimo redeploys; when regenerating fails, fetch the current bundle URLs from `podimo.com` / `studio.podimo.com` and update those constants before rerunning. `podimo-dl.py` does `from queries import *` / `from mutations import *`, so regenerating may rename or remove the symbols it consumes (e.g. `queryTokenWithCredentials`, `queryUsePodcastsExistQuery`, `queryPodcastEpisodes`) — verify those still exist after regenerating.
+**`queries.py` and `mutations.py` are AUTO-GENERATED — do not hand-edit.** They are produced by `generate.py`, which fetches Podimo's webpack bundles and extracts every embedded `query …` / `mutation …` string. The bundle URLs hard-coded in `generate.py` (`js_url`, `js_studio_urls`) are versioned and will 404 when Podimo redeploys; when regenerating fails, fetch the current bundle URLs from `podimo.com` / `studio.podimo.com` and update those constants before rerunning. `podimo-dl.py` does `from queries import *` / `from mutations import *`, so regenerating may rename or remove the symbols it consumes (e.g. `queryTokenWithCredentials`, `queryUsePodcastsExistQuery`) — verify those still exist after regenerating.
+
+When the regenerated query exists but has the wrong selection set, `podimo-dl.py` defines its own `gql(...)` override at the top of the file rather than editing the generated module. Current overrides: `queryPodcastEpisodesForDownload` (the generated `queryPodcastEpisodes` is the studio/creator variant — `converted: false, published: false`, no `audio` / `accessLevel`; the override uses `converted: true, published: true` and selects `audio { url }` + `accessLevel`) and `queryPodcastInfoForDownload` (minimal `podcastById` for folder-name lookup — note: the mobile/listener schema at `podimo.com/graphql` does *not* have `publicPodcastById` — that's a web-only field — even though `queries.py` is full of web queries that use it; use `podcastById` instead, and use a variable name that differs from `podcastId` since the validator's "never used" error is what you'll get if the field is unknown and gets stripped). If a future regeneration restores the listener-facing shape, the overrides can be dropped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+No lint config. Install deps with `pip install -r requirements.txt`.
+
+```bash
+# Run the downloader (interactive prompts unless flags / env vars fill them in)
+python podimo-dl.py [-p PODCAST_NAME] [-d] [--premium-only] [--overwrite] [-o OUTPUT_DIR]
+
+# Regenerate queries.py and mutations.py from Podimo's JS bundles
+python generate.py
+
+# Run tests (stdlib unittest, fully mocked — no network)
+python -m unittest test_podimo_dl.py -v
+# Single test:
+python -m unittest test_podimo_dl.GetPodcastEpisodesTest.test_paginates_until_short_page
+```
+
+Note: `test_podimo_dl.py` imports `podimo-dl.py` via `importlib.util` because the hyphenated filename isn't a legal Python module name.
+
+CLI flags: `-d/--download` skips the "Download Episodes?" prompt; `--premium-only` filters to PREMIUM episodes; `--overwrite` re-downloads existing files.
+
+Credentials come from `.env` (gitignored, copied from `.env.example`): `PODIMO_EMAIL`, `PODIMO_PASSWORD`, `PODIMO_IS_CREATOR`. Any unset value falls through to an interactive prompt; `PODIMO_IS_CREATOR` is parsed as truthy on `1`/`true`/`yes`.
+
+## Architecture
+
+This is a single-purpose CLI that downloads podcast episodes from Podimo via their internal GraphQL API. Three concerns are split across files:
+
+**`podimo-dl.py`** — the only runtime entry point. The `PodimoAPI` class wraps two GraphQL clients:
+- `studio_client` → `https://studio.podimo.com/graphql` (used only when `is_creator=True`, with `scope: 'CREATOR'`)
+- `public_client` → `https://podimo.com/graphql` (everything else: search, episode listing)
+
+After `login()`, both transports get a shared `Host: graphql.pdm-gateway.com` header alongside the bearer token — Podimo routes the request URLs through that gateway, so this header override is required for subsequent calls to authenticate.
+
+The flow is: `login` → `search_podcast` (substring-filters `publicSearch` results by title and returns the first match) → `get_podcast_episodes` → `download_episode` (urllib download, then `eyed3` writes ID3v2.4 tags). Track numbers are parsed from title prefixes like `#42 Episode Title` via regex; otherwise track 0.
+
+**`queries.py` and `mutations.py` are AUTO-GENERATED — do not hand-edit.** They are produced by `generate.py`, which fetches Podimo's webpack bundles and extracts every embedded `query …` / `mutation …` string. The bundle URLs hard-coded in `generate.py` (`js_url`, `js_studio_urls`) are versioned and will 404 when Podimo redeploys; when regenerating fails, fetch the current bundle URLs from `podimo.com` / `studio.podimo.com` and update those constants before rerunning. `podimo-dl.py` does `from queries import *` / `from mutations import *`, so regenerating may rename or remove the symbols it consumes (e.g. `queryTokenWithCredentials`, `queryUsePodcastsExistQuery`, `queryPodcastEpisodes`) — verify those still exist after regenerating.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # podimo-dl
 
+Download episodes from a Podimo podcast you have access to.
+
+## Setup
+
+Requires Python 3. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env` and fill it in:
+
+```
+PODIMO_EMAIL=you@example.com
+PODIMO_PASSWORD=...
+PODIMO_IS_CREATOR=false   # set to true to log in with creator/studio scope
+```
+
+Any value left out of `.env` falls through to an interactive prompt at runtime.
+
 ## Usage
-You need to have Python installed.
-Just run the program using `python podimo-dl.py`.
-Optionally create a `config.py` file using the format provided in `config.sample.py`.
+
+```bash
+python podimo-dl.py [-p PODCAST_NAME_OR_UUID] [-d] [--premium-only] [--overwrite] [-o OUTPUT_BASE_DIR]
+```
+
+`-p` accepts either a podcast name (substring-matched, first hit wins) or a podcast UUID (8-4-4-4-12 hex), which skips the search step. Without `-p` you'll be prompted.
+
+Other flags:
+
+- `-d, --download` — skip the "Download Episodes?" confirmation prompt.
+- `--premium-only` — only download episodes flagged `PREMIUM`.
+- `--overwrite` — re-download episodes whose files already exist.
+- `-o OUTPUT_BASE_DIR` — base output directory (default `episodes/`).
+
+Files land at `<base>/<podcast title>/<episode title>.mp3`. The per-podcast folder is created automatically.

--- a/config.sample.py
+++ b/config.sample.py
@@ -1,3 +1,0 @@
-email = 'your podimo email'
-password = 'your podimo password'
-is_creator = False

--- a/podimo-dl.py
+++ b/podimo-dl.py
@@ -6,8 +6,27 @@ import os
 import re
 import eyed3
 from pathlib import Path
+from dotenv import load_dotenv
 from mutations import *
 from queries import *
+
+# The auto-generated queryPodcastEpisodes in queries.py is the studio/creator
+# variant and does not select audio.url — which download_episode needs.
+# Override it here with the listener-facing field set.
+queryPodcastEpisodesForDownload = gql('''
+query PodcastEpisodes($podcastId: String!, $limit: Int!, $offset: Int!) {
+  podcastEpisodes(podcastId: $podcastId, limit: $limit, offset: $offset, converted: true, published: true) {
+    id
+    title
+    description
+    datetime
+    accessLevel
+    audio {
+      url
+    }
+  }
+}
+''')
 
 class PodimoAPI:
     def __init__(self):
@@ -27,6 +46,7 @@ class PodimoAPI:
             result = self.public_client.execute(queryTokenWithCredentials, variable_values={
                 'email': email,
                 'password': password,
+                'scope': 'MOBILE',
             })
 
         token = result["tokenWithCredentials"]["token"]
@@ -35,27 +55,32 @@ class PodimoAPI:
             'user-os': 'android',
             'user-locale': 'en-US',
             'user-agent': 'okhttp/4.9.1',
-            'Host': 'graphql.pdm-gateway.com',
             'authorization': token,
         }
 
     def search_podcast(self, search_query, region="de"):
         result = self.public_client.execute(queryUsePodcastsExistQuery, variable_values={
             'search': search_query,
-            'region': region
         })
-        search_result = [r for r in result["publicSearch"] if search_query in r["title"]]
+        search_result = [r for r in result["podcastsAutocomplete"] if search_query in r["title"]]
         if len(search_result) > 0:
             return search_result[0]
         return None
 
-    def get_podcast_episodes(self, podcast_id, limit=1000, offset=0):
-        result = self.public_client.execute(queryPodcastEpisodes, variable_values={
-            'podcastId': podcast_id,
-            'limit': limit,
-            'offset': offset,
-        })
-        return result["podcastEpisodes"]
+    def get_podcast_episodes(self, podcast_id, page_size=100):
+        episodes = []
+        offset = 0
+        while True:
+            result = self.public_client.execute(queryPodcastEpisodesForDownload, variable_values={
+                'podcastId': podcast_id,
+                'limit': page_size,
+                'offset': offset,
+            })
+            page = result["podcastEpisodes"]
+            episodes.extend(page)
+            if len(page) < page_size:
+                return episodes
+            offset += page_size
 
 
     def download_episode(self, podcast_episode, output_folder=None, overwrite=False):
@@ -81,37 +106,40 @@ def do_it_question(question):
     xy = input(question + " (Y/n) > ")
     return not xy.lower() == "n"
 
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--podcast", )
-    parser.add_argument("-c", "--config", action="store_true")
+    parser.add_argument("-p", "--podcast", help="podcast name (substring match) or UUID")
     parser.add_argument("-d", "--download", action="store_true")
     parser.add_argument("--premium-only", action="store_true")
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("-o", "--output")
     args = parser.parse_args()
 
-    if (args.config and os.path.exists("config.py")) or do_it_question("Use config.py?"):
-        from config import email, password, is_creator
-    else:
-        email = input("Email > ")
-        password = input("Password > ")
-        is_creator = False
+    load_dotenv()
+    email = os.getenv("PODIMO_EMAIL") or input("Email > ")
+    password = os.getenv("PODIMO_PASSWORD") or input("Password > ")
+    is_creator = os.getenv("PODIMO_IS_CREATOR", "").strip().lower() in ("1", "true", "yes")
 
     podimo = PodimoAPI()
     podimo.login(email, password, is_creator)
 
     if not args.podcast:
-        search_string = input("Podcast Name > ")
+        search_string = input("Podcast Name or UUID > ")
     else:
         search_string = args.podcast
 
-    podcast = podimo.search_podcast(search_string)
-    if not podcast:
-        print("Not found!")
-        return
+    if UUID_RE.match(search_string.strip()):
+        podcast_id = search_string.strip()
+    else:
+        podcast = podimo.search_podcast(search_string)
+        if not podcast:
+            print("Not found!")
+            return
+        podcast_id = podcast["id"]
 
-    episodes = podimo.get_podcast_episodes(podcast["id"])
+    episodes = podimo.get_podcast_episodes(podcast_id)
 
     if args.premium_only:
         episodes = [x for x in filter(lambda e: e["accessLevel"] == "PREMIUM", episodes)]

--- a/podimo-dl.py
+++ b/podimo-dl.py
@@ -29,8 +29,8 @@ query PodcastEpisodes($podcastId: String!, $limit: Int!, $offset: Int!) {
 ''')
 
 queryPodcastInfoForDownload = gql('''
-query PodcastInfo($podcastId: String!) {
-  publicPodcastById(podcastId: $podcastId) {
+query PodcastInfo($showId: String!) {
+  podcastById(podcastId: $showId) {
     id
     title
   }
@@ -82,9 +82,9 @@ class PodimoAPI:
 
     def get_podcast_title(self, podcast_id):
         result = self.public_client.execute(queryPodcastInfoForDownload, variable_values={
-            'podcastId': podcast_id,
+            'showId': podcast_id,
         })
-        info = result.get("publicPodcastById")
+        info = result.get("podcastById")
         return info["title"] if info else None
 
     def get_podcast_episodes(self, podcast_id, page_size=100):

--- a/podimo-dl.py
+++ b/podimo-dl.py
@@ -28,6 +28,19 @@ query PodcastEpisodes($podcastId: String!, $limit: Int!, $offset: Int!) {
 }
 ''')
 
+queryPodcastInfoForDownload = gql('''
+query PodcastInfo($podcastId: String!) {
+  publicPodcastById(podcastId: $podcastId) {
+    id
+    title
+  }
+}
+''')
+
+
+def sanitize_filename(name):
+    return "".join(c for c in name if c.isalpha() or c.isdigit() or c in ' #').rstrip() or "untitled"
+
 class PodimoAPI:
     def __init__(self):
         self.transport1 = AIOHTTPTransport(url="https://studio.podimo.com/graphql")
@@ -67,6 +80,13 @@ class PodimoAPI:
             return search_result[0]
         return None
 
+    def get_podcast_title(self, podcast_id):
+        result = self.public_client.execute(queryPodcastInfoForDownload, variable_values={
+            'podcastId': podcast_id,
+        })
+        info = result.get("publicPodcastById")
+        return info["title"] if info else None
+
     def get_podcast_episodes(self, podcast_id, page_size=100):
         episodes = []
         offset = 0
@@ -87,8 +107,7 @@ class PodimoAPI:
         name = podcast_episode["title"]
         url = podcast_episode["audio"]["url"]
 
-        sane_name = "".join([c for c in name if c.isalpha() or c.isdigit() or c in ' #']).rstrip()
-        fn = f'{sane_name}.mp3'
+        fn = f'{sanitize_filename(name)}.mp3'
         if output_folder:
             fn = f'{output_folder}/{fn}'
 
@@ -132,12 +151,14 @@ def main():
 
     if UUID_RE.match(search_string.strip()):
         podcast_id = search_string.strip()
+        podcast_title = podimo.get_podcast_title(podcast_id) or podcast_id
     else:
         podcast = podimo.search_podcast(search_string)
         if not podcast:
             print("Not found!")
             return
         podcast_id = podcast["id"]
+        podcast_title = podcast["title"]
 
     episodes = podimo.get_podcast_episodes(podcast_id)
 
@@ -148,8 +169,12 @@ def main():
         print(" > ", e["title"])
 
     if args.download or do_it_question("Download Episodes?"):
+        base_dir = Path(args.output) if args.output else Path("episodes")
+        target_dir = base_dir / sanitize_filename(podcast_title)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
         for e in episodes:
-            fn = podimo.download_episode(e, args.output, args.overwrite)
+            fn = podimo.download_episode(e, str(target_dir), args.overwrite)
 
             title_with_track_num = re.match(r"^#?([0-9]{1,}) (.+)", e["title"])
             if title_with_track_num:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+gql[aiohttp]
+eyed3
+requests
+python-dotenv

--- a/test_podimo_dl.py
+++ b/test_podimo_dl.py
@@ -1,0 +1,67 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_spec = importlib.util.spec_from_file_location(
+    "podimo_dl", Path(__file__).parent / "podimo-dl.py"
+)
+podimo_dl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(podimo_dl)
+
+
+class GetPodcastEpisodesTest(unittest.TestCase):
+    def setUp(self):
+        self.api = podimo_dl.PodimoAPI()
+        self.api.public_client = MagicMock()
+
+    def test_single_short_page_returns_immediately(self):
+        self.api.public_client.execute.return_value = {
+            "podcastEpisodes": [{"id": "a"}, {"id": "b"}],
+        }
+
+        result = self.api.get_podcast_episodes("pod-1", page_size=100)
+
+        self.assertEqual(result, [{"id": "a"}, {"id": "b"}])
+        self.assertEqual(self.api.public_client.execute.call_count, 1)
+        call = self.api.public_client.execute.call_args_list[0]
+        self.assertEqual(
+            call.kwargs["variable_values"],
+            {"podcastId": "pod-1", "limit": 100, "offset": 0},
+        )
+
+    def test_paginates_until_short_page(self):
+        full_page = [{"id": str(i)} for i in range(100)]
+        tail = [{"id": str(i)} for i in range(100, 150)]
+        self.api.public_client.execute.side_effect = [
+            {"podcastEpisodes": full_page},
+            {"podcastEpisodes": tail},
+        ]
+
+        result = self.api.get_podcast_episodes("pod-1", page_size=100)
+
+        self.assertEqual(len(result), 150)
+        self.assertEqual(result[0]["id"], "0")
+        self.assertEqual(result[-1]["id"], "149")
+
+        offsets = [
+            c.kwargs["variable_values"]["offset"]
+            for c in self.api.public_client.execute.call_args_list
+        ]
+        self.assertEqual(offsets, [0, 100])
+
+    def test_stops_on_empty_page(self):
+        full_page = [{"id": str(i)} for i in range(3)]
+        self.api.public_client.execute.side_effect = [
+            {"podcastEpisodes": full_page},
+            {"podcastEpisodes": []},
+        ]
+
+        result = self.api.get_podcast_episodes("pod-1", page_size=3)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(self.api.public_client.execute.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary                                                

  This branch makes the downloader work against Podimo's current GraphQL schema and adds a few quality-of-life improvements.                             
  
  ### API drift fixes                                                                                                                                    
  - **Login**: `tokenWithCredentials` now requires a `$scope` argument — `MOBILE` for listeners, `CREATOR` for the studio flow. Without it, login fails
  outright.                                                                                                                                              
  - **Search**: regenerated query returns `podcastsAutocomplete` (not the old `publicSearch`) and no longer accepts `$region`.
  - **Episode listing**: the auto-generated `queryPodcastEpisodes` in `queries.py` is the studio/creator variant (`converted: false, published: false`)  
  and omits `audio { url }` and `accessLevel`, which caused a `KeyError: 'audio'` on download. Added a local `gql()` override                            
  (`queryPodcastEpisodesForDownload`) with the listener-facing selection.                                                                                
  - **Pagination**: `get_podcast_episodes` now pages through results — the server caps `limit` at 100, so podcasts with more than 100 episodes were      
  getting truncated.                                                                                                                                     
  - **Title lookup**: added `queryPodcastInfoForDownload` using `podcastById` (the mobile schema does *not* have `publicPodcastById` — it's a web-only
  field even though `queries.py` is full of web queries that use it).                                                                                    
  - **Header**: dropped the `Host: graphql.pdm-gateway.com` override that was producing 403s on post-login calls against the current API.
                                                                                                                                                         
  ### Configuration                                         
  - Replace `config.py` with `.env` / `.env.example` loaded via `python-dotenv` (`PODIMO_EMAIL`, `PODIMO_PASSWORD`, `PODIMO_IS_CREATOR`). Any unset value
   falls through to an interactive prompt.                                                                                                               
  - Drop the `-c/--config` flag.
                                                                                                                                                         
  ### CLI / output                                          
  - `-p` accepts either a podcast name (substring-matched, first hit wins) or a podcast UUID (8-4-4-4-12 hex). UUIDs skip the search step and are passed 
  straight to the episodes query, with the title fetched via `podcastById` for folder naming.                                                            
  - Default output base is now `episodes/` (overridable via `-o`).
  - Files land at `<base>/<sanitized podcast title>/<sanitized episode title>.mp3`; the per-podcast folder is created automatically.                     
                                                                                                                                                         
  ### Repo hygiene                                                                                                                                       
  - Add `requirements.txt` (`gql[aiohttp]`, `eyed3`, `requests`, `python-dotenv`).                                                                       
  - Add `test_podimo_dl.py` — stdlib `unittest`, fully mocked GraphQL client, covers `get_podcast_episodes` pagination.                                  
  - Add `CLAUDE.md` documenting the architecture, the auto-generated nature of `queries.py`/`mutations.py`, and the local override pattern used when the 
  regenerated query has the wrong shape.                                                                                                                 
  - Update `README.md` for the `.env` workflow and new flags.                                                                                            
  - `.gitignore`: ignore `.env`, downloaded `.mp3`s, and `episodes/`.                                                                                    
                                                                                                                                                         
  ## Test plan                                                                                                                                           
  ### CLI / output
  - `-p` accepts either a podcast name (substring-matched, first hit wins) or a podcast UUID (8-4-4-4-12 hex). UUIDs skip the search step and are passed
  straight to the episodes query, with the title fetched via `podcastById` for folder naming.
  - Default output base is now `episodes/` (overridable via `-o`).
  - Files land at `<base>/<sanitized podcast title>/<sanitized episode title>.mp3`; the per-podcast folder is created automatically.

  ### Repo hygiene
  - Add `requirements.txt` (`gql[aiohttp]`, `eyed3`, `requests`, `python-dotenv`).
  - Add `test_podimo_dl.py` — stdlib `unittest`, fully mocked GraphQL client, covers `get_podcast_episodes` pagination.
  - Add `CLAUDE.md` documenting the architecture, the auto-generated nature of `queries.py`/`mutations.py`, and the local override pattern used when the
  regenerated query has the wrong shape.
  - Update `README.md` for the `.env` workflow and new flags.
  - `.gitignore`: ignore `.env`, downloaded `.mp3`s, and `episodes/`.
