### PR TITLE
Enable download by Id too

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ You will be prompted for your Podimo credentials and the podcast name to search 
 Optionally, create a `config.py` file using the format provided in `config.sample.py` to skip the credential prompts:
 
 ```bash
-python podimo-dl.py --config -p "Podcast Name" --download
+python podimo-dl.py --config -p "Podcast Name or ID" --download
 ```
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
-| `-p / --podcast` | Podcast name to search for |
+| `-p / --podcast` | Podcast name to search for or Podcast ID |
 | `-c / --config` | Load credentials from `config.py` |
 | `-d / --download` | Download without prompting |
 | `--premium-only` | Only download premium episodes |

--- a/podimo-dl.py
+++ b/podimo-dl.py
@@ -9,6 +9,13 @@ from pathlib import Path
 from mutations import *
 from queries import *
 
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-"
+    r"[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{12}$"
+)
 class PodimoAPI:
     def __init__(self):
         self.transport1 = AIOHTTPTransport(url="https://studio.podimo.com/graphql")
@@ -126,12 +133,16 @@ def main():
     else:
         search_string = args.podcast
 
-    podcast = podimo.search_podcast(search_string)
-    if not podcast:
+    if UUID_RE.match(search_string):
+        podcast_id = search_string
+    else:
+        podcast_id = podimo.search_podcast(search_string)["id"]
+
+    if not podcast_id:
         print("Not found!")
         return
 
-    episodes = podimo.get_podcast_episodes(podcast["id"])
+    episodes = podimo.get_podcast_episodes(podcast_id)
 
     if args.premium_only:
         episodes = [x for x in filter(lambda e: e["accessLevel"] == "PREMIUM", episodes)]


### PR DESCRIPTION
There are podcasts with **same name** and we always try to download the first found podcast. To avoid more user interaction by asking author or anything else, now we can specify the podcast ID instead of the name.